### PR TITLE
Remote Procedure calls sample with C#

### DIFF
--- a/Docker-Commands.txt
+++ b/Docker-Commands.txt
@@ -1,0 +1,18 @@
+Docker commands:
+
+docker images
+
+docker build -t signalr-svc:v1 .
+
+docker run --publish 15000:15000 signalr-svc:v1
+
+// Get running containers
+docker ps
+
+docker container stop e92318f1e0e5
+
+docker rm e92318f1e0e5
+
+docker rmi --force abc....
+
+docker rmi --force signalr-svc:v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+WORKDIR /app
+EXPOSE 15000
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /src
+COPY ["SignalRSvc/SignalRSvc.csproj", "SignalRSvc/"]
+COPY ["MessageProviderLib/MessageProviderLib.csproj", "MessageProviderLib/"]
+COPY ["Infrastructure/SignalRBaseHubServerLib/SignalRBaseHubServerLib.csproj", "Infrastructure/SignalRBaseHubServerLib/"]
+COPY ["Infrastructure/DtoLib/DtoLib.csproj", "Infrastructure/DtoLib/"]
+COPY ["RemoteCallable/RemoteInterfaces/RemoteInterfaces.csproj", "RemoteCallable/RemoteInterfaces/"]
+COPY ["Infrastructure/AsyncAutoResetEventLib/AsyncAutoResetEventLib.csproj", "Infrastructure/AsyncAutoResetEventLib/"]
+COPY ["RemoteCallable/RemoteImplementations/RemoteImplementations.csproj", "RemoteCallable/RemoteImplementations/"]
+RUN dotnet restore "SignalRSvc/SignalRSvc.csproj"
+COPY . .
+WORKDIR "/src/SignalRSvc"
+RUN dotnet publish "SignalRSvc.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "SignalRSvc.dll"]

--- a/Infrastructure/AsyncAutoResetEventLib/AsyncAutoResetEvent.cs
+++ b/Infrastructure/AsyncAutoResetEventLib/AsyncAutoResetEvent.cs
@@ -1,0 +1,47 @@
+﻿// https://blogs.msdn.microsoft.com/pfxteam/2012/02/11/building-async-coordination-primitives-part-2-asyncautoresetevent/
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AsyncAutoResetEventLib
+{
+    public class AsyncAutoResetEvent
+    {
+        private readonly Queue<TaskCompletionSource<bool>> _waits = new Queue<TaskCompletionSource<bool>>();
+        private bool _signaled;
+
+        public Task WaitAsync()
+        {
+            lock (_waits)
+            {
+                if (_signaled)
+                {
+                    _signaled = false;
+                    return Task.FromResult(true);
+                }
+                else
+                {
+                    var tcs = new TaskCompletionSource<bool>();
+                    _waits.Enqueue(tcs);
+                    return tcs.Task;
+                }
+            }
+        }
+
+        public void Set()
+        {
+            TaskCompletionSource<bool> toRelease = null;
+            lock (_waits)
+            {
+                if (_waits.Count > 0)
+                    toRelease = _waits.Dequeue();
+                else
+                    if (!_signaled)
+                        _signaled = true;
+            }
+
+            if (toRelease != null)
+                toRelease.SetResult(true);
+        }
+    }
+}

--- a/Infrastructure/AsyncAutoResetEventLib/AsyncAutoResetEventLib.csproj
+++ b/Infrastructure/AsyncAutoResetEventLib/AsyncAutoResetEventLib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Infrastructure/DtoLib/DtoLib.csproj
+++ b/Infrastructure/DtoLib/DtoLib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RemoteCallable\RemoteInterfaces\RemoteInterfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Infrastructure/DtoLib/RpcDto.cs
+++ b/Infrastructure/DtoLib/RpcDto.cs
@@ -1,0 +1,39 @@
+﻿namespace DtoLib
+{
+    public class RpcDtoCommon 
+    {
+        public string ClientId { get; set; }
+
+        public string Id { get; set; }
+
+        public DtoStatus Status { get; set; }
+
+        public string InterfaceName { get; set; }
+
+        public string MethodName { get; set; }
+    }
+
+    public class RpcDtoRequest : RpcDtoCommon
+    {
+        public DtoData[] Args { get; set; }
+    }
+
+    public class RpcDtoResponse : RpcDtoCommon
+    {
+        public DtoData Result { get; set; }
+    }
+
+    public class DtoData 
+    {
+        public string TypeName { get; set; }
+        public object Data { get; set; }
+    }
+
+    public enum DtoStatus
+    {
+        None = 0,
+        Error = 1,
+        Created = 2,
+        Processed = 3,
+    }
+}

--- a/Infrastructure/SignalRBaseHubClientLib/HubClient.cs
+++ b/Infrastructure/SignalRBaseHubClientLib/HubClient.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Net.Http;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Microsoft.AspNetCore.SignalR.Client;
+using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.Logging;
+using DtoLib;
+
+namespace SignalRBaseHubClientLib
+{
+    public class HubClient : IDisposable
+    {
+        public string Url { get; }
+        public string ClientId { get; }
+
+        public HubConnection Connection { get; protected set; }
+        protected CancellationTokenSource _cts = new CancellationTokenSource();
+        protected ILogger _logger;
+
+        private Dictionary<string, Type> _dctType = new Dictionary<string, Type>();
+
+        private readonly Action<ILogger, bool, RpcDtoRequest> _beforeCall;
+        private readonly Action<ILogger, bool, RpcDtoRequest, object, TimeSpan, Exception> _afterCall;
+
+        #region Ctor
+
+        public HubClient(string url, 
+                         ILoggerFactory loggerFactory = null, 
+                         string clientId = null,
+                         Action<ILogger, bool, RpcDtoRequest> beforeCall = null,
+                         Action<ILogger, bool, RpcDtoRequest, object, TimeSpan, Exception> afterCall = null)
+        {
+            _logger = loggerFactory?.CreateLogger<HubClient>();
+            Url = url;
+            ClientId = string.IsNullOrWhiteSpace(clientId) ? $"{Guid.NewGuid()}" : clientId;
+
+            _beforeCall = beforeCall;
+            _afterCall = afterCall;
+        }
+
+        #endregion // Ctor
+
+        #region Type manipulations
+
+        public HubClient RegisterInterface<TInterface>() where TInterface : class
+        {
+            foreach (var mi in typeof(TInterface).GetMethods())
+            {
+                var rt = mi.ReturnType;
+                _dctType[rt.FullName] = rt;
+            }
+
+            return this;
+        }
+
+        private object GetResult(JObject jo)
+        {
+            if (jo == null)
+                return null;
+
+            if (!jo.TryGetValue("result", out JToken jt))
+                return null;
+
+            var typFullName = jt.First().Values<string>().First();
+            var result = jt.Last().Values<object>().First();
+
+            object jOb = result as JArray;
+            if (jOb == null)
+                jOb = result as JObject;
+            if (jOb == null)
+                jOb = result as JValue;
+
+            if (jOb != null) 
+            {
+                var type = _dctType[typFullName];
+                var jVal = jOb as JValue;
+                return jVal != null && jVal?.Value.GetType() == type
+                        ? jVal.Value
+                        : JsonSerializer.Deserialize($"{jOb}", _dctType[typFullName], new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            }
+
+            return null;
+        }
+
+        #endregion // Type manipulations
+
+        #region StartConnection, Subscribe
+
+        public async Task<HubClient> StartConnectionAsync(int retryIntervalMs = 0, int numOfAttempts = 0)
+        {
+            Connection = new HubConnectionBuilder().WithUrl(Url, options =>
+                options.HttpMessageHandlerFactory = (message) =>
+                {
+                    if (message is HttpClientHandler clientHandler)
+                        // bypass TLS certificate
+                        clientHandler.ServerCertificateCustomValidationCallback += 
+                            (sender, certificate, chain, sslPolicyErrors) => true;
+                    return message;
+                })             
+                .Build();
+
+            for (var i = 0; i < numOfAttempts; i++)
+            {
+                try
+                {
+                    await Connection.StartAsync();
+                    return this;
+                }
+                catch (Exception e)
+                {
+                    if (i < numOfAttempts - 1)
+                        await Task.Delay(numOfAttempts);
+                    else
+                    {
+                        var errMessage = $"Hub connection on '{Url}' had failed. ";
+                        _logger?.LogError(errMessage, e);
+                        throw new Exception(errMessage, e);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public async void Subscribe<T>(Action<T> callback)
+        {
+            if (Connection == null || _cts.Token.IsCancellationRequested || callback == null)
+                return;
+
+            try
+            {
+                var channel = await Connection.StreamAsChannelAsync<T>("StartStreaming", _cts.Token);
+                while (await channel.WaitToReadAsync())
+                    while (channel.TryRead(out var t))
+                    {
+                        try
+                        {
+                            callback(t);
+                        }
+                        catch (Exception e)
+                        {
+                            var errMessage = $"Hub '{Url}' Subscribe(): callback had failed. ";
+                            _logger.LogError(errMessage, e);
+                            throw new Exception(errMessage, e);
+                        }
+                    }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger?.LogInformation($"Hub '{Url}': cancellation");
+            }
+        }
+
+        #endregion // StartConnection, Subscribe
+
+        #region Rpc, Invoke 
+
+        public Task<object> RpcAsync(string interfaceName, string methodName, params object[] args) =>
+            RpcAsync(false, interfaceName, methodName, args);
+
+        public async void RpcOneWay(string interfaceName, string methodName, params object[] args) =>
+            await RpcAsync(true, interfaceName, methodName, args);
+
+        private async Task<object> RpcAsync(bool isOneWay, string interfaceName, string methodName, object[] args)
+        {
+            if (!IsReady)
+                return null;
+
+            var rpcArgs = new RpcDtoRequest
+            {
+                ClientId = ClientId,
+                Id = $"{Guid.NewGuid()}",
+                Status = DtoStatus.Created,
+                InterfaceName = interfaceName,
+                MethodName = methodName,
+                Args = args?.Select(a => new DtoData { TypeName = a.GetType().FullName, Data = a })?.ToArray()
+            };
+
+            object obResult = null;
+            Exception ex = null;
+            var sw = new Stopwatch();
+            try
+            {
+                _beforeCall?.Invoke(_logger, isOneWay, rpcArgs);
+
+                sw.Start();
+                var result = await Connection.InvokeAsync<object>(isOneWay ? "RpcOneWay" : "Rpc", rpcArgs, _cts.Token);
+                obResult = isOneWay ? null : GetResult((JObject)result);
+            }
+            catch (Exception e)
+            {
+                ex = e;
+                var errMessage = $"Hub '{Url}' InvokeAsync() of method '{methodName}()' had failed. ";
+                _logger?.LogError(errMessage, e);
+                throw new Exception(errMessage, e);
+            }
+            finally 
+            {
+                sw.Stop();
+                _afterCall?.Invoke(_logger, isOneWay, rpcArgs, obResult, sw.Elapsed, ex);
+            }
+
+            return obResult;
+        }
+
+        public async Task<object> InvokeAsync(string methodName, params object[] args)
+        {
+            if (!IsReady)
+                return null;
+
+            try
+            {
+                return await Connection.InvokeAsync<object>(methodName, args, _cts.Token);
+            }
+            catch (Exception e)
+            {
+                var errMessage = $"Hub '{Url}' InvokeAsync() of method '{methodName}()' had failed. ";
+                _logger?.LogError(errMessage, e);
+                throw new Exception(errMessage, e);
+            }
+        }
+
+        private bool IsReady => Connection != null && !_cts.Token.IsCancellationRequested;
+
+        #endregion // Rpc, Invoke
+
+        #region Cancel, Dispose
+
+        public async Task Cancel() 
+        {
+            _logger?.LogInformation($"Hub '{Url}': 'Cancel()' is called");
+            var count = await RpcAsync("_", "KillClientSessionsIfExist", ClientId);
+            _cts.Cancel();
+        }
+
+        public void Dispose() 
+        {
+            _logger?.LogInformation($"Hub '{Url}': 'Dispose()' is called");
+
+            if (!_cts.IsCancellationRequested)
+                Cancel().Wait();
+
+            Connection.DisposeAsync().Wait();
+        }
+
+        #endregion // Cancel, Dispose
+    }
+}

--- a/Infrastructure/SignalRBaseHubClientLib/SignalRBaseHubClientLib.csproj
+++ b/Infrastructure/SignalRBaseHubClientLib/SignalRBaseHubClientLib.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DtoLib\DtoLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Infrastructure/SignalRBaseHubServerLib/Container.cs
+++ b/Infrastructure/SignalRBaseHubServerLib/Container.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using DtoLib;
+
+namespace SignalRBaseHubServerLib
+{
+    class Container
+    {
+        #region Vars
+
+        internal Dictionary<string, BaseInterfaceDescriptor> DctInterface { get; } = new Dictionary<string, BaseInterfaceDescriptor>()
+        {
+            {
+                "_",
+                new BaseInterfaceDescriptor
+                {
+                    DctType = new Dictionary<string, Type>()
+                    {
+                        { "System.String", typeof(string) }
+                    }
+                }
+            }
+        };
+
+        private ILoggerFactory _loggerFactory;
+        private ILogger _logger;
+        private Timer _timer;
+
+        #endregion // Vars
+
+        #region SetLogger
+
+        internal void SetLogger(ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory == null)
+                return;
+
+            if (_logger == null)
+            {
+                _loggerFactory = loggerFactory;
+                _logger = loggerFactory.CreateLogger<Container>();
+            }
+        }
+
+        #endregion // SetLogger
+
+        #region Register
+
+        internal void RegisterSingleton<TInterface>(TInterface ob)
+        {
+            var @interface = typeof(TInterface);
+            DctInterface[@interface.Name] = new InterfaceDescriptorSingleton
+            {
+                Ob = ob,
+                ImplType = ob.GetType(),
+                InstantiationKind = Instantiation.Singleton,
+                DctType = GetTypeDictionary(@interface),
+            };
+        }
+
+        internal void Register(Type @interface, Type implType, Instantiation instanceType, int sessionLifeTimeInMin = -1)
+        {
+            var isPerSession = instanceType == Instantiation.PerSession;
+            DctInterface[@interface.Name] = BaseInterfaceDescriptor.InterfaceDescriptorFactory(implType, instanceType, GetTypeDictionary(@interface));
+
+            if (isPerSession && sessionLifeTimeInMin > 0 && _timer == null)
+            {
+                var sessionLifeTime = TimeSpan.FromMinutes(sessionLifeTimeInMin);
+                _timer = new Timer(_ =>
+                {
+                    var now = DateTime.UtcNow;
+                    foreach (var cdct in DctInterface.Values?
+                                .Where(d => d.IsPerSession)?
+                                .Select(d => (d as InterfaceDescriptorPerSession).CdctSession))
+                    {
+                        foreach (var clientId in cdct?.Keys?.ToArray())
+                            if (now - new DateTime(cdct[clientId].LastActivationInTicks) > sessionLifeTime)
+                                cdct.TryRemove(clientId, out SessionDescriptor psd);
+                    }
+                },
+                null, TimeSpan.Zero, TimeSpan.FromMinutes(sessionLifeTimeInMin));
+            }
+        }
+
+        #endregion // Register
+
+        #region Type manipulations
+
+        private static Dictionary<string, Type> GetTypeDictionary(Type interfaceType)
+        {
+            var dctType = new Dictionary<string, Type>();
+            foreach (var mi in interfaceType.GetMethods())
+                foreach (var pi in mi.GetParameters())
+                    dctType[pi.ParameterType.FullName] = pi.ParameterType;
+
+            return dctType;
+        }
+
+        internal object[] GetMethodArguments(RpcDtoRequest arg)
+        {
+            if (!DctInterface.TryGetValue(arg.InterfaceName, out BaseInterfaceDescriptor descriptor))
+                return null;
+
+            var methodParams = new List<object>();
+            foreach (var dtoData in arg?.Args)
+            {
+                var je = (JsonElement)dtoData.Data;
+
+                if (!descriptor.DctType.TryGetValue(dtoData.TypeName, out Type type))
+                    throw new Exception($"Type '{dtoData.TypeName}' is not registered");
+
+                methodParams.Add(JsonSerializer.Deserialize(je.GetRawText(), type, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }));
+            }
+
+            return methodParams.ToArray();
+        }
+
+        #endregion // Type manipulations
+
+        #region Resolve, CreateInstance
+
+        internal object Resolve(string interafceName, string clientId = null)
+        {
+            if (!DctInterface.TryGetValue(interafceName, out BaseInterfaceDescriptor descriptor))
+                return null;
+
+            if (descriptor.IsSingleton)
+                // Singleton
+                return (descriptor as InterfaceDescriptorSingleton).Ob;
+
+            if (descriptor.ImplType != null)
+            {
+                if (descriptor.IsPerCall)
+                    // Per Call
+                    return CreateInstanceWithLoggerIfSupported(descriptor.ImplType);
+
+                if (descriptor.IsPerSession)
+                {
+                    // Per Session
+                    var psd = descriptor as InterfaceDescriptorPerSession;
+                    if (psd.CdctSession.TryGetValue(clientId, out SessionDescriptor sd))
+                    {
+                        sd.LastActivationInTicks = DateTime.UtcNow.Ticks;
+                        return sd.ob;
+                    }
+
+                    psd.CdctSession[clientId] = sd = new SessionDescriptor()
+                    {
+                        ob = CreateInstanceWithLoggerIfSupported(psd.ImplType),
+                        LastActivationInTicks = DateTime.UtcNow.Ticks,
+                    };
+
+                    return sd.ob;
+                }
+            }
+
+            return null;
+        }
+
+        private object CreateInstanceWithLoggerIfSupported(Type type) =>
+            AssignLoggerIfSupported(Activator.CreateInstance(type));
+
+        private object AssignLoggerIfSupported(object ob)
+        {
+            var log = ob as ILog;
+            if (log != null)
+                log.LoggerFactory = _loggerFactory;
+            return ob;
+        }
+
+        #endregion Resolve, CreateInstance
+    }
+}

--- a/Infrastructure/SignalRBaseHubServerLib/Descriptors.cs
+++ b/Infrastructure/SignalRBaseHubServerLib/Descriptors.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace SignalRBaseHubServerLib
+{
+    enum Instantiation
+    {
+        None = 0,
+        Singleton,
+        PerCall,
+        PerSession
+    }
+
+    class BaseInterfaceDescriptor
+    {
+        public Type ImplType { get; set; }
+        public Instantiation InstantiationKind { get; set; } = Instantiation.None;
+        public Dictionary<string, Type> DctType { get; set; }
+
+        public static BaseInterfaceDescriptor InterfaceDescriptorFactory(
+            Type implType, Instantiation instanceType, Dictionary<string, Type> dctType)
+        {
+            BaseInterfaceDescriptor interfaceDescriptor;
+            switch (instanceType)
+            {
+                case Instantiation.Singleton:
+                    interfaceDescriptor = new InterfaceDescriptorSingleton();
+                    break;
+
+                case Instantiation.PerCall:
+                    interfaceDescriptor = new InterfaceDescriptorPerCall();
+                    break;
+
+                case Instantiation.PerSession:
+                    interfaceDescriptor = new InterfaceDescriptorPerSession();
+                    break;
+
+                default:
+                    interfaceDescriptor = new BaseInterfaceDescriptor();
+                    break;
+            }
+
+            interfaceDescriptor.ImplType = implType;
+            interfaceDescriptor.InstantiationKind = instanceType;
+            interfaceDescriptor.DctType = dctType;
+
+            return interfaceDescriptor;
+        }
+
+        public bool IsPerCall => InstantiationKind == Instantiation.PerCall;
+        public bool IsPerSession => InstantiationKind == Instantiation.PerSession;
+        public bool IsSingleton => InstantiationKind == Instantiation.Singleton;
+    }
+
+    class InterfaceDescriptorSingleton : BaseInterfaceDescriptor
+    {
+        public object Ob { get; set; }
+    }
+
+    class InterfaceDescriptorPerCall : BaseInterfaceDescriptor
+    {
+    }
+
+    class InterfaceDescriptorPerSession : BaseInterfaceDescriptor
+    {
+        public ConcurrentDictionary<string, SessionDescriptor> CdctSession { get; } = 
+            new ConcurrentDictionary<string, SessionDescriptor>();
+    }
+
+    class SessionDescriptor
+    {
+        public object ob;
+
+        private long _lastActivationInTicks;
+        public long LastActivationInTicks
+        {
+            get => Interlocked.Read(ref _lastActivationInTicks);
+            set => Interlocked.Exchange(ref _lastActivationInTicks, value);
+        }
+    }
+}

--- a/Infrastructure/SignalRBaseHubServerLib/Interfaces.cs
+++ b/Infrastructure/SignalRBaseHubServerLib/Interfaces.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace SignalRBaseHubServerLib
+{
+    public interface IStreamingDataProvider<T>
+    {
+        T Current { get; }
+    }
+
+    public interface ISetEvent
+    {
+        void SetEvent();
+        bool IsValid { get; }
+    }
+
+    public interface IDirectCall
+    {
+        object DirectCall(string methodName, params object[] args);
+    }
+
+    public interface ILog
+    {
+        ILoggerFactory LoggerFactory { set; }
+    }
+}

--- a/Infrastructure/SignalRBaseHubServerLib/ObservableEx.cs
+++ b/Infrastructure/SignalRBaseHubServerLib/ObservableEx.cs
@@ -1,0 +1,34 @@
+﻿//https://github.com/aspnet/SignalR-samples/blob/master/StockTickR/StockTickRApp/ObservableExtensions.cs
+
+using System;
+using System.Threading.Channels;
+
+namespace SignalRBaseHubServerLib
+{
+    static class ObservableEx
+    {
+        internal static ChannelReader<T> AsChannelReader<T>(this IObservable<T> observable, int? maxBufferSize = null)
+        {
+            // This sample shows adapting an observable to a ChannelReader without 
+            // back pressure, if the connection is slower than the producer, memory will
+            // start to increase.
+
+            // If the channel is bounded, TryWrite will return false and effectively
+            // drop items.
+
+            // The other alternative is to use a bounded channel, and when the limit is reached
+            // block on WaitToWriteAsync. This will block a thread pool thread and isn't recommended and isn't shown here.
+            var channel = maxBufferSize != null ? Channel.CreateBounded<T>(maxBufferSize.Value) : Channel.CreateUnbounded<T>();
+
+            var disposable = observable.Subscribe(
+                                    value => channel.Writer.TryWrite(value),
+                                    error => channel.Writer.TryComplete(error),
+                                    () => channel.Writer.TryComplete());
+
+            // Complete the subscription on the reader completing
+            channel.Reader.Completion.ContinueWith(task => disposable.Dispose());
+
+            return channel.Reader;
+        }
+    }
+}

--- a/Infrastructure/SignalRBaseHubServerLib/RpcAndStreamingHub.cs
+++ b/Infrastructure/SignalRBaseHubServerLib/RpcAndStreamingHub.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Text;
+using System.Diagnostics;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using AsyncAutoResetEventLib;
+using DtoLib;
+
+namespace SignalRBaseHubServerLib
+{
+    public class RpcAndStreamingHub<T> : Hub, ISetEvent
+    {
+        #region Vars
+
+        protected readonly IStreamingDataProvider<T> _streamingDataProvider;
+        private readonly AsyncAutoResetEvent _aev = new AsyncAutoResetEvent();
+
+        private int _isValid = 0;
+
+        protected readonly ILogger _logger;
+
+        private static readonly Container _container;
+
+        private readonly Action<ILogger, bool, string, string, string, string, object[]> _beforeCall;
+        private readonly Action<ILogger, bool, string, string, string, string, object[], object, TimeSpan, Exception> _afterCall;
+
+        #endregion // Vars
+
+        #region Ctor
+
+        static RpcAndStreamingHub() => 
+            _container = new Container();
+
+        protected RpcAndStreamingHub(
+            ILoggerFactory loggerFactory = null, 
+            StreamingDataProvider<T> streamingDataProvider = null,
+            Action<ILogger, bool, string, string, string, string, object[]> beforeCall = null,
+            Action<ILogger, bool, string, string, string, string, object[], object, TimeSpan, Exception> afterCall = null)
+        {
+            _logger = loggerFactory?.CreateLogger<RpcAndStreamingHub<T>>();           
+            IsValid = true;
+            streamingDataProvider?.Add(this);
+            _streamingDataProvider = streamingDataProvider;
+            _container.SetLogger(loggerFactory);
+            _beforeCall = beforeCall;
+            _afterCall = afterCall;
+        }
+
+        #endregion // Ctor
+
+        #region Register
+
+        public static void RegisterSingleton<TInterface>(TInterface ob) =>
+            _container.RegisterSingleton(ob);
+
+        public static void RegisterPerCall<TInterface, TImpl>() where TImpl : TInterface, new() =>
+            _container.Register(typeof(TInterface), typeof(TImpl), Instantiation.PerCall);
+
+        public static void RegisterPerSession<TInterface, TImpl>(int sessionLifeTimeInMin = -1) where TImpl : TInterface, new() =>
+            _container.Register(typeof(TInterface), typeof(TImpl), Instantiation.PerSession, sessionLifeTimeInMin);
+
+        #endregion // Register
+
+        #region Rpc, StartStreaming, KillClientSessionsIfExist
+
+        public RpcDtoResponse Rpc(RpcDtoRequest arg) => Rpc(arg, false);
+
+        public void RpcOneWay(RpcDtoRequest arg) => Rpc(arg, true);
+
+        private RpcDtoResponse Rpc(RpcDtoRequest arg, bool isOneWay)
+        {
+            if (!_container.DctInterface.ContainsKey(arg.InterfaceName))
+                throw new Exception($"Interface '{arg.InterfaceName}' is not regidtered");
+
+            var methodArgs = _container.GetMethodArguments(arg);
+            var localOb = _container.Resolve(arg.InterfaceName, arg.ClientId);
+
+            IDirectCall directCall = null;
+            if (localOb == null)
+                localOb = this;
+            else
+                directCall = localOb as IDirectCall;
+
+            object result = null;
+            Exception ex = null;
+            var isDirectCall = directCall != null;
+            var sw = new Stopwatch();
+            try
+            {
+                _beforeCall?.Invoke(_logger, isDirectCall, arg.Id, arg.ClientId, arg.InterfaceName, arg.MethodName, methodArgs);
+                sw.Start();
+                result = isDirectCall
+                    ? directCall.DirectCall(arg.MethodName, methodArgs)
+                    : localOb?.GetType().GetMethod(arg.MethodName)?.Invoke(localOb, methodArgs);
+            }
+            catch (Exception e)
+            {
+                _logger?.LogError($"Method '{arg.InterfaceName}.{arg.MethodName}()' failed", e);
+                throw e;
+            }
+            finally 
+            {
+                sw.Stop();
+                _afterCall?.Invoke(_logger, isDirectCall, arg.Id, arg.ClientId, arg.InterfaceName, arg.MethodName, methodArgs, result, sw.Elapsed, ex);
+            }
+
+            return isOneWay 
+                    ? null
+                    : new RpcDtoResponse
+                    {
+                        ClientId = arg.ClientId,
+                        Id = arg.Id,
+                        InterfaceName = arg.InterfaceName,
+                        MethodName = arg.MethodName,
+                        Status = DtoStatus.Processed,
+                        Result = new DtoData { TypeName = result.GetType().FullName, Data = result }
+                    };
+
+            //await Clients.All.SendAsync("ReceiveMessage", "...", retOb.ToString());
+        }
+
+        public ChannelReader<T> StartStreaming() =>
+            _streamingDataProvider == null
+                ? null 
+                : Observable.Create<T>(async observer =>
+                {
+                    while (!Context.ConnectionAborted.IsCancellationRequested)
+                    {
+                        await _aev.WaitAsync();
+                        observer.OnNext(_streamingDataProvider.Current);
+                    }
+                }).AsChannelReader();
+
+        public int KillClientSessionsIfExist(string clientId)
+        {
+            var interfacesCount = 0;
+            var sb = new StringBuilder();
+            foreach (var k in _container.DctInterface.Keys)
+            {
+                var descriptor = _container.DctInterface[k];
+                if (descriptor.IsPerSession)
+                {
+                    var psd = (InterfaceDescriptorPerSession)descriptor;
+                    if (psd.CdctSession != null && psd.CdctSession.TryRemove(clientId, out SessionDescriptor sd))
+                    {
+                        interfacesCount++;
+                        sb.Append($"'{k}', ");
+                    }
+                }
+            }
+
+            if (sb.Length > 0)
+            {
+                var tempStr = sb.ToString().Substring(0, sb.Length - 2);
+                _logger?.LogInformation($"Sessions for client '{clientId}' have been deleted for interfaces {tempStr}");
+            }
+
+            return interfacesCount;
+        }
+
+        #endregion // Rpc, StartStreaming, KillClientSessionsIfExist
+
+        #region Aux
+
+        public bool IsValid
+        {
+            get => Interlocked.Exchange(ref _isValid, _isValid) == 1;
+            private set => Interlocked.Exchange(ref _isValid, value ? 1 : 0);
+        }
+        
+        public void SetEvent() =>
+            _aev.Set();
+
+        #endregion // Aux
+
+        #region Dispose
+
+        protected override void Dispose(bool disposing)
+        {
+            IsValid = false;
+            base.Dispose(disposing);
+        }
+
+        #endregion // Dispose
+    }
+}

--- a/Infrastructure/SignalRBaseHubServerLib/SignalRBaseHubServerLib.csproj
+++ b/Infrastructure/SignalRBaseHubServerLib/SignalRBaseHubServerLib.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
+    <PackageReference Include="System.Reactive.Linq" Version="4.1.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AsyncAutoResetEventLib\AsyncAutoResetEventLib.csproj" />
+    <ProjectReference Include="..\DtoLib\DtoLib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Core">
+      <HintPath>..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnetcore.signalr.core\1.0.1\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Infrastructure/SignalRBaseHubServerLib/StreamingDataProvider.cs
+++ b/Infrastructure/SignalRBaseHubServerLib/StreamingDataProvider.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace SignalRBaseHubServerLib
+{
+    public class StreamingDataProvider<T> : IStreamingDataProvider<T>
+    {
+        private List<ISetEvent> _lstSetEvent = new List<ISetEvent>();
+
+        private T _dto;
+
+        public T Current
+        {
+            get
+            {
+                lock (this)
+                    return _dto;
+            }
+            set
+            {
+                lock (this)
+                {
+                    _dto = value;
+                    foreach (var se in _lstSetEvent.ToArray())
+                    {
+                        if (se.IsValid)
+                            se.SetEvent();
+                        else
+                            _lstSetEvent.Remove(se);
+                    }
+                }
+            }
+        }
+
+        public void Add(ISetEvent se)
+        {
+            lock (this)
+            {
+                if (!_lstSetEvent.Contains(se))
+                    _lstSetEvent.Add(se);
+            }
+        }
+    }
+}
+

--- a/MessageProviderLib/MessageEventProvider.cs
+++ b/MessageProviderLib/MessageEventProvider.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using RemoteInterfaces;
+using SignalRBaseHubServerLib;
+
+namespace MessageProviderLib
+{
+    public class MessageEventProvider : StreamingDataProvider<Message>
+    {
+        private const int rndLowLimit = 0;
+        private const int rndUpperLimit = 999;
+        private const int intervalInMs = 3000;
+
+        private Timer _timer;
+        private Random _random = new Random(11);
+
+        private static MessageEventProvider _helper;
+        public static MessageEventProvider Instance
+        {
+            get
+            {
+                if (_helper == null)
+                    _helper = new MessageEventProvider();
+
+                return _helper;
+            }
+        }
+
+        private MessageEventProvider() =>
+            _timer = new Timer(_ => Current = new Message { ClientId = $"{Guid.NewGuid()}", Data = _random.Next(rndLowLimit, rndUpperLimit) }, null, 0, intervalInMs);
+    }
+}

--- a/MessageProviderLib/MessageProviderLib.csproj
+++ b/MessageProviderLib/MessageProviderLib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\SignalRBaseHubServerLib\SignalRBaseHubServerLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,166 @@
-# RPC_Csharp
+# Remote Procedure Calls (RPC) with .NET 5: Streaming and Replacement for WCF 
+
+This work presents streaming and WCF replacement solution with .NET 5 
+
+## Introduction
+
+Solution provides the following functionality for inter-process communication in .NET 5:
+
+- RPC using interface, particularly to replace WCF
+- RPC with asynchronous response, and 
+- Streaming
+
+The solution is based on **SignalR** library. It uses WebSocket as its main transport type with long polling as a fallback.
+
+The following features are supported:
+
+- Binaries run in Windows and Linux alike
+- Communication channel may be encrypted with TLS.
+- Client is not necessarily .NET . It may be e. g. front end Web application.
+
+## Brief Solution Description
+
+Library *SignalRBaseHubServerLib* provides infrastructure for server side, whereas *SignalRBaseHubClientLib* contains base class *HubClient* for hub client.  *DtoLib* defines Data Transfer Objects (DTO) for request and response shared between server and client. *AsyncAutoResetEventLib* provides asynchronous version of auto-reset event used in streaming. *SignalRBaseHubServerLib* provides interfaces for streaming (*IStreamingDataProvider&lt;T&gt;* and *ISetEvent*), logging *ILog* and WCF replacement *IDirectCall*.  
+
+*MessageProviderLib* library supplies class *MessageEventProvider : StreamingDataProvider&lt;Message&gt;* providing event stream.
+
+*RemoteCallable* has *RemoteInterfaces* and *RemoteImplementations* libraries used for WCF replacement. The former provides interfaces that supposed to be called remotely and shared between server and client. The latter contains implementation of those interfaces in the server. The implementations may also implement additional interfaces *ILog* and *IDirectCall* mentioned above. Implementing the only method *DirectCall()* of *IDirectCall* interface, class allows server to call methods of its main interface directly without reflection which is more efficient. If interface *IDirectCall* is not implemented then server calls methods of main interface using reflection.    
+
+## Hub Implementation by Server
+
+In the Server side create a hub class derived from *RpcAndStreamingHub&lt;Message&gt;* with a static constructor to register RPC interfaces with the hub. Public constructor of the class accepts optional arguments *beforeCall* and *afterCall*  methods. If provided, they are called before and after call of interface method respectively.  Example of implementation of a hub is given below.
+
+```
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using SignalRBaseHubServerLib;
+using MessageProviderLib;
+using RemoteInterfaces;
+using RemoteImplementations;
+
+namespace SignalRSvc.Hubs
+{
+    // The hub class provides data streaming to client subscriber.
+    // This is implemented with its base class.
+    // The base class takes event provider as a ctor parameter. 
+    public class AHub : RpcAndStreamingHub<Message>
+    {
+        static AHub() 
+        {
+            RegisterPerCall<IRemoteCall1, RemoteCall1>();
+            RegisterPerSession<IRemoteCall2, RemoteCall2>();
+            RegisterSingleton<IRemoteCall3>(new RemoteCall3(5));
+        }
+
+        public AHub(ILoggerFactory loggerFactory)
+            : base(loggerFactory,
+                   MessageEventProvider.Instance,
+                   (logger, isDirectCall, requestId, clientId, interfaceName, methodName, methodArgs) =>
+                   {
+						// ...
+                   },
+                   (logger, isDirectCall, requestId, clientId, interfaceName, methodName, methodArgs, 
+						result, duration, exception) =>
+                   {
+						// ...
+                   })
+        {
+        }
+
+        public async Task<Message[]> ProcessMessage(Message[] args)
+        {
+            StringBuilder sbClients = new();
+            StringBuilder sbData = new();
+
+            if (args != null && args.Length > 0)
+            {
+                sbClients.Append("Clients: ");
+                foreach (var clientId in args.Select(dto => dto.ClientId).Distinct())
+                    sbClients.Append($"{clientId} ");
+
+                sbData.Append("--> Data: ");
+                foreach (var dto in args)
+                    sbData.Append($"{dto.Data} ");
+            }
+            else
+            {
+                sbClients.Append("No clients");
+                sbData.Append("No data available");
+            }
+
+            // Send message to all clients
+            await Clients.All.SendAsync("ReceiveMessage", sbClients.ToString(), sbData.ToString());
+
+            return args;
+        }
+    }
+}
+
+```
+
+## Remote Procedure Call (RPC) Using Interface
+
+An RPC interface is registered with client and server. The server provides class implementing the interface. Client calls method *RpcAsync()* taking interface and method names as arguments, along with arguments of the called method itself. Then the method is executed on server side and client gets its result. Broadcasting result to other clients may be implemented, if required. Server supports Singleton, PerCall and PerSession instance models, similar to those in WCF.  One way call ("fire-and-forget") is also available with method *RpcOneWay()*.
+
+In the Client side instance of *HubClient* class is created and its methods *RegisterInterface&lt;IInterface&gt;* are called concluded with *async* method *StartConnectionAsync()*:
+
+```
+// Create hub client and connect to server
+using var hubClient = await new HubClient(url, loggerFactory, $"Client-{Guid.NewGuid()}", 
+			null,
+			(logger, isOneWay, request, result, duration, exception) => 
+			{
+				// ...
+			})
+		.RegisterInterface<IRemoteCall1>()
+		.RegisterInterface<IRemoteCall2>()
+		.RegisterInterface<IRemoteCall3>()
+		.StartConnectionAsync(retryIntervalMs: 1000, numOfAttempts: 15);
+```
+
+Then remote calls are carried out as following:
+
+```
+var str = await hubClient.RpcAsync("IRemoteCall1", "Echo", " some text");
+var ret3 = (Ret3)await hubClient.RpcAsync("IRemoteCall3", "GetIdAndParam");
+```
+
+## RPC with Asynchronous Response
+
+This feature requires in the Server side the same hub class derived from class *RpcAndStreamingHub&lt;Message&gt;* like in RPC case.
+Client should first provide handler for notification from Server:
+
+```
+// Client provides handler for server's call of method ReceiveMessage
+hubClient.Connection.On("ReceiveMessage", (string s0, string s1) => 
+	logger.LogInformation($"ReceiveMessage: {s0} {s1}"));
+```
+
+and then call remote method on Server with *InvokeAsync()*:
+
+```
+// Client calls server's method ProcessMessage
+var jarr = (JArray)await hubClient.InvokeAsync("ProcessMessage",
+	new[] { new Message { ... }, new Message { ... }, });
+```
+
+## Streaming
+
+Class *MessageEventProvider : StreamingDataProvider&lt;Message&gt;* generates stream of messages (in this implementation it is singleton). Its instance is attached to Server as an argument in the hub base class constructor. Client subscribes to this stream providing appropriate callback in method *Subscribe&lt;Message&gt;()*:
+
+```
+// Client subscribes for stream of Message objects providing appropriate handler
+hubClient.Subscribe<Message>(arg => logger.LogInformation($"Stream: {arg}"));
+```
+
+## How to Run Sample
+
+To run the sample fast please do the following. In the root directory 
+
+1. Run file *_build_solution.cmd* to build the solution. Build result will be placed to *bin* directory.
+2. Run files *_run_Server.cmd* and *_run_Client.cmd* to start server and client respectively.
+
+

--- a/RemoteCallable/RemoteImplementations/RemoteCall1.cs
+++ b/RemoteCallable/RemoteImplementations/RemoteCall1.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using RemoteInterfaces;
+using SignalRBaseHubServerLib;
+
+namespace RemoteImplementations
+{
+    public class RemoteCall1 : IRemoteCall1, ILog
+    {
+        private ILogger _logger;
+        public ILoggerFactory LoggerFactory { set => _logger = value?.CreateLogger<RemoteCall2>(); }
+
+        public RetOuter[] Foo(string name, Arg1[] arg1s)
+        {
+            var args1 = new Arg1[]
+                {
+                    new Arg1 { Id = "0", Arg2Props = new List<Arg2> { new Arg2 { Id = "0.0" }, new Arg2 { Id = "0.1" } } },
+                    new Arg1 { Id = "1", Arg2Props = new List<Arg2> { new Arg2 { Id = "1.0" }, new Arg2 { Id = "1.1" } } }
+                };
+
+            //TEST
+            if (arg1s == null || arg1s.Length != 2 || arg1s[1].Id != "1" || arg1s[1].Id != "1" || arg1s[1].Arg2Props[1].Id != "1.1")
+                throw new Exception("TEST failes - wrong aruments");
+
+            _logger?.LogDebug("*** RemoteCall1.Foo()");
+            return new RetOuter[]
+                {
+                    new RetOuter
+                    {
+                        Inners = new RetInner[]
+                        {
+                            new RetInner { Id = "0_00" }, new RetInner { Id = "0_01" },
+                            new RetInner { Id = "0_10" }, new RetInner { Id = "0_11" }
+                        }
+                    },
+                    new RetOuter
+                    {
+                        Inners = new RetInner[]
+                        {
+                            new RetInner { Id = "1_00" }, new RetInner { Id = "1_01" },
+                            new RetInner { Id = "1_10" }, new RetInner { Id = "1_11" }
+                        }
+                    }
+                };
+        }
+
+        public string Echo(string text) => $"Echo1: {text}";
+
+        public int Simple() => 42;
+    }
+}

--- a/RemoteCallable/RemoteImplementations/RemoteCall2.cs
+++ b/RemoteCallable/RemoteImplementations/RemoteCall2.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Extensions.Logging;
+using RemoteInterfaces;
+using SignalRBaseHubServerLib;
+
+namespace RemoteImplementations
+{
+    public class RemoteCall2 : IRemoteCall2, IDirectCall, ILog
+    {
+        private static int objectsCount = 0;
+
+        private int _id;
+        private ILogger _logger;
+
+        public ILoggerFactory LoggerFactory { set => _logger = value?.CreateLogger<RemoteCall2>(); }
+
+        public RemoteCall2()
+        {
+            _id = ++objectsCount;
+            _logger?.LogDebug($"*** RemoteCall2.Ctor() -> {_id}");
+        }
+
+        #region IRemoteCall2 implementation
+
+        public int Foo(string name, Arg1[] arg1s)
+        {
+            _logger?.LogDebug($"*** RemoteCall2.Foo() -> {_id}");
+            return _id;
+        }
+
+        public string Echo(string text)
+        {
+            var echo = $"Echo2: {text}";
+            _logger?.LogDebug($"*** Echo -> {echo}");
+            return echo;
+        }
+
+        #endregion // IRemoteCall2 implementation
+
+        public object DirectCall(string methodName, params object[] args)
+        {
+            switch (methodName)
+            {
+                case "Foo":
+                    return Foo((string)args[0], (Arg1[])args[1]);
+
+                case "Echo":
+                    return Echo((string)args[0]);
+            }
+
+            return null;
+        }
+    }
+}

--- a/RemoteCallable/RemoteImplementations/RemoteCall3.cs
+++ b/RemoteCallable/RemoteImplementations/RemoteCall3.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using RemoteInterfaces;
+using SignalRBaseHubServerLib;
+
+namespace RemoteImplementations
+{
+    public class RemoteCall3 : IRemoteCall3, ILog
+    {
+        private ILogger _logger;
+        public ILoggerFactory LoggerFactory { set => _logger = value?.CreateLogger<RemoteCall2>(); }
+
+        private Guid _id;
+        private int _n;
+
+        public RemoteCall3(int n)
+        {
+            _n = n;
+            _id = Guid.NewGuid();
+        }
+
+        public Ret3 GetIdAndParam() => new Ret3 { Id = _id, Param = _n };
+    }
+}

--- a/RemoteCallable/RemoteImplementations/RemoteImplementations.csproj
+++ b/RemoteCallable/RemoteImplementations/RemoteImplementations.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Infrastructure\SignalRBaseHubServerLib\SignalRBaseHubServerLib.csproj" />
+    <ProjectReference Include="..\RemoteInterfaces\RemoteInterfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RemoteCallable/RemoteInterfaces/Data.cs
+++ b/RemoteCallable/RemoteInterfaces/Data.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RemoteInterfaces
+{
+    public class Arg1
+    {
+        public string Id { get; set; }
+        public List<Arg2> Arg2Props { get; set; }
+    }
+
+    public class Arg2
+    {
+        public string Id { get; set; }
+    }
+
+    public class RetOuter
+    {
+        public RetInner[] Inners { get; set; }
+    }
+
+    public class RetInner
+    {
+        public string Id { get; set; }
+    }
+
+    public class Ret3
+    {
+        public Guid Id { get; set; }
+        public int Param { get; set; }
+    }
+}

--- a/RemoteCallable/RemoteInterfaces/Interfaces.cs
+++ b/RemoteCallable/RemoteInterfaces/Interfaces.cs
@@ -1,0 +1,20 @@
+﻿namespace RemoteInterfaces
+{
+    public interface IRemoteCall1
+    {
+        RetOuter[] Foo(string name, Arg1[] arg1s);
+        string Echo(string text);
+        int Simple();
+    }
+
+    public interface IRemoteCall2
+    {
+        int Foo(string name, Arg1[] arg1s);
+        string Echo(string text);
+    }
+
+    public interface IRemoteCall3
+    {
+        Ret3 GetIdAndParam();
+    }
+}

--- a/RemoteCallable/RemoteInterfaces/Message.cs
+++ b/RemoteCallable/RemoteInterfaces/Message.cs
@@ -1,0 +1,18 @@
+﻿namespace RemoteInterfaces
+{
+    public class Message
+    {
+        public string ClientId { get; set; }
+
+        public string Id { get; set; }
+
+        public object Payload { get; set; }
+
+        public int Data { get; set; }
+
+        public override string ToString() =>
+            $"{ClientId}     {Data}";
+
+        public Arg1[] Args { get; set; }
+    }
+}

--- a/RemoteCallable/RemoteInterfaces/RemoteInterfaces.csproj
+++ b/RemoteCallable/RemoteInterfaces/RemoteInterfaces.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Rpc_Sample.sln
+++ b/Rpc_Sample.sln
@@ -1,0 +1,85 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infrastructure", "Infrastructure", "{8133C2C6-8FAA-417F-8629-1C5916999DE3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncAutoResetEventLib", "Infrastructure\AsyncAutoResetEventLib\AsyncAutoResetEventLib.csproj", "{E26E7F7D-C5CC-480A-8E20-ACF55504908C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SignalRBaseHubClientLib", "Infrastructure\SignalRBaseHubClientLib\SignalRBaseHubClientLib.csproj", "{EE38515E-B18A-4046-90DD-B9069E1152CB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SignalRBaseHubServerLib", "Infrastructure\SignalRBaseHubServerLib\SignalRBaseHubServerLib.csproj", "{6A081747-6E93-46A5-9E0A-E46E89D6E9BC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SignalRSvc", "SignalRSvc\SignalRSvc.csproj", "{6920A0B6-8F63-4BB2-A490-87CABF62FD5E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RemoteCallable", "RemoteCallable", "{DEC9351C-04DF-470A-91D3-8D0B3A34B627}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteInterfaces", "RemoteCallable\RemoteInterfaces\RemoteInterfaces.csproj", "{405E5F10-5BC2-4EA9-A7BF-BA77AF90011D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteImplementations", "RemoteCallable\RemoteImplementations\RemoteImplementations.csproj", "{376B3588-717B-4503-875D-63501A2AA571}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DtoLib", "Infrastructure\DtoLib\DtoLib.csproj", "{1C2FE88C-66A2-4CEA-A5B4-3036D9AA212D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageProviderLib", "MessageProviderLib\MessageProviderLib.csproj", "{AC98F800-C920-47DF-B1A6-78ECB61C7188}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SignalRClient", "SignalRClient\SignalRClient.csproj", "{7ED14F49-FB3F-4E43-8B97-E9AFEAF54405}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E26E7F7D-C5CC-480A-8E20-ACF55504908C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E26E7F7D-C5CC-480A-8E20-ACF55504908C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E26E7F7D-C5CC-480A-8E20-ACF55504908C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E26E7F7D-C5CC-480A-8E20-ACF55504908C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE38515E-B18A-4046-90DD-B9069E1152CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE38515E-B18A-4046-90DD-B9069E1152CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE38515E-B18A-4046-90DD-B9069E1152CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE38515E-B18A-4046-90DD-B9069E1152CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A081747-6E93-46A5-9E0A-E46E89D6E9BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A081747-6E93-46A5-9E0A-E46E89D6E9BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A081747-6E93-46A5-9E0A-E46E89D6E9BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A081747-6E93-46A5-9E0A-E46E89D6E9BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6920A0B6-8F63-4BB2-A490-87CABF62FD5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6920A0B6-8F63-4BB2-A490-87CABF62FD5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6920A0B6-8F63-4BB2-A490-87CABF62FD5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6920A0B6-8F63-4BB2-A490-87CABF62FD5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{405E5F10-5BC2-4EA9-A7BF-BA77AF90011D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{405E5F10-5BC2-4EA9-A7BF-BA77AF90011D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{405E5F10-5BC2-4EA9-A7BF-BA77AF90011D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{405E5F10-5BC2-4EA9-A7BF-BA77AF90011D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{376B3588-717B-4503-875D-63501A2AA571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{376B3588-717B-4503-875D-63501A2AA571}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{376B3588-717B-4503-875D-63501A2AA571}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{376B3588-717B-4503-875D-63501A2AA571}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C2FE88C-66A2-4CEA-A5B4-3036D9AA212D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C2FE88C-66A2-4CEA-A5B4-3036D9AA212D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C2FE88C-66A2-4CEA-A5B4-3036D9AA212D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C2FE88C-66A2-4CEA-A5B4-3036D9AA212D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC98F800-C920-47DF-B1A6-78ECB61C7188}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC98F800-C920-47DF-B1A6-78ECB61C7188}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC98F800-C920-47DF-B1A6-78ECB61C7188}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC98F800-C920-47DF-B1A6-78ECB61C7188}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7ED14F49-FB3F-4E43-8B97-E9AFEAF54405}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7ED14F49-FB3F-4E43-8B97-E9AFEAF54405}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7ED14F49-FB3F-4E43-8B97-E9AFEAF54405}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7ED14F49-FB3F-4E43-8B97-E9AFEAF54405}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E26E7F7D-C5CC-480A-8E20-ACF55504908C} = {8133C2C6-8FAA-417F-8629-1C5916999DE3}
+		{EE38515E-B18A-4046-90DD-B9069E1152CB} = {8133C2C6-8FAA-417F-8629-1C5916999DE3}
+		{6A081747-6E93-46A5-9E0A-E46E89D6E9BC} = {8133C2C6-8FAA-417F-8629-1C5916999DE3}
+		{405E5F10-5BC2-4EA9-A7BF-BA77AF90011D} = {DEC9351C-04DF-470A-91D3-8D0B3A34B627}
+		{376B3588-717B-4503-875D-63501A2AA571} = {DEC9351C-04DF-470A-91D3-8D0B3A34B627}
+		{1C2FE88C-66A2-4CEA-A5B4-3036D9AA212D} = {8133C2C6-8FAA-417F-8629-1C5916999DE3}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B295322B-4D9D-478A-8CC5-5C63080DAA67}
+	EndGlobalSection
+EndGlobal

--- a/SignalRClient/ProgramSignalRClient.cs
+++ b/SignalRClient/ProgramSignalRClient.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using SignalRBaseHubClientLib;
+using RemoteInterfaces;
+
+namespace SignalRClient
+{
+    class ProgramSignalRClient
+    {
+        private const string Url    = "http://localhost:15000/hub/a";
+        private const string UrlTls = "https://localhost:15001/hub/a";
+
+        private static async Task Main(string[] args)
+        {
+            var url = args.Length > 0 && args[0].ToLower() == "tls" ? UrlTls : Url;
+
+            using ILoggerFactory loggerFactory =
+                LoggerFactory.Create(builder =>
+                    builder.AddSimpleConsole(options =>
+                    {
+                        options.IncludeScopes = false;
+                        options.SingleLine = true;
+                        options.TimestampFormat = "hh:mm:ss ";
+                    }));
+            var logger = loggerFactory.CreateLogger<ProgramSignalRClient>();
+
+            logger.LogInformation("SignalRClientTest started");
+
+            // Create hub client and connect to server
+            using var hubClient = await new HubClient(url, loggerFactory, $"Client-{Guid.NewGuid()}", 
+                        null,
+                        (logger, isOneWay, request, result, duration, exception) => 
+                        {
+                            var message = $"Method '{request.InterfaceName}.{request.MethodName}()', isOneWay = {isOneWay}, requestId = {request.Id} ";
+                            if (exception == null)
+                                logger?.LogInformation($"{message}OK, duration = {duration.TotalMilliseconds} ms");
+                            else
+                                logger?.LogError($"{message}", exception);
+                        })
+                    .RegisterInterface<IRemoteCall1>()
+                    .RegisterInterface<IRemoteCall2>()
+                    .RegisterInterface<IRemoteCall3>()
+                    .StartConnectionAsync(retryIntervalMs: 1000, numOfAttempts: 15);
+
+            #region Streaming
+
+            // Client subscribes for stream of Message objects providing appropriate handler
+            hubClient.Subscribe<Message>(arg => logger.LogInformation($"Stream: {arg}"));
+
+            #endregion Streaming
+
+            AutoResetEvent ev = new(false);
+
+            var args1 = new Arg1[]
+                {
+                    new Arg1 { Id = "0", Arg2Props = new() { new() { Id = "0.0" }, new() { Id = "0.1" } } },
+                    new Arg1 { Id = "1", Arg2Props = new() { new() { Id = "1.0" }, new() { Id = "1.1" } } }
+                };
+
+            _ = Task.Run(async () =>
+            {
+                // Client provides handler for server's call of method ReceiveMessage
+                hubClient.Connection.On("ReceiveMessage", (string s0, string s1) => 
+                    logger.LogInformation($"ReceiveMessage: {s0} {s1}"));
+
+                while (!ev.WaitOne(3000))
+                {
+                    #region Rpc
+
+                    var str = await hubClient.RpcAsync("IRemoteCall1", "Echo", " some text");
+
+                    var ret3_1 = (Ret3)await hubClient.RpcAsync("IRemoteCall3", "GetIdAndParam");
+                    var ret3_2 = (Ret3)await hubClient.RpcAsync("IRemoteCall3", "GetIdAndParam");
+
+                    //TEST
+                    if (ret3_1.Id != ret3_2.Id || ret3_1.Param != ret3_2.Param)
+                        throw new Exception("TEST failes - wrong Ret3");
+
+                    var result42 = await hubClient.RpcAsync("IRemoteCall1", "Simple");
+
+                    var task1 = hubClient.RpcAsync("IRemoteCall1", "Foo", "theName", args1);
+                    var task2 = hubClient.RpcAsync("IRemoteCall2", "Foo", "theName", args1);
+
+                    hubClient.RpcOneWay("IRemoteCall1", "Foo", "theName", args1);
+                    hubClient.RpcOneWay("IRemoteCall2", "Foo", "theName", args1);
+
+                    var echo = await hubClient.RpcAsync("IRemoteCall1", "Echo", " my text");
+
+                    hubClient.RpcOneWay("IRemoteCall2", "Foo", "theName", args1);
+
+                    var result1 = (RetOuter[])await task1;
+                    var result2 = (int)await task2;
+
+                    //TEST
+                    if (result1 == null || result1.Length != 2 || result1[1].Inners[3].Id != "1_11")
+                        throw new Exception("TEST failes - wrong arguments");
+
+                    var durationTicksFoo1 = await TimeWatch(hubClient.RpcAsync, "IRemoteCall1", "Foo", "theName", args1);
+                    var durationTicksFoo2 = await TimeWatch(hubClient.RpcAsync, "IRemoteCall2", "Foo", "theName", args1);
+
+                    var durationTicksEcho1 = await TimeWatch(hubClient.RpcAsync, "IRemoteCall1", "Echo", " some text");
+                    var durationTicksEcho2 = await TimeWatch(hubClient.RpcAsync, "IRemoteCall2", "Echo", " some text");
+
+                    var durationTicksFooOneWay1 = await TimeWatch(hubClient.RpcOneWay, "IRemoteCall1", "Foo", "theName", args1);
+                    var durationTicksFooOneWay2 = await TimeWatch(hubClient.RpcOneWay, "IRemoteCall2", "Foo", "theName", args1);
+
+                    var strFoo = ((float)durationTicksFoo1 / durationTicksFoo2).ToString("f1");
+                    var strEcho = ((float)durationTicksEcho1 / durationTicksEcho2).ToString("f1");
+                    logger.LogInformation($"durationTicksFoo1  (reflected call): {durationTicksFoo1}");
+                    logger.LogInformation($"durationTicksFoo2  (direct call):    {durationTicksFoo2}, Ratio: {strFoo}");
+                    logger.LogInformation($"durationTicksEcho1 (reflected call): {durationTicksEcho1}");
+                    logger.LogInformation($"durationTicksEcho2 (direct call):    {durationTicksEcho2}, Ratio: {strEcho}");
+                    logger.LogInformation($"durationTicksFooOneWay1:             {durationTicksFooOneWay1}");
+                    logger.LogInformation($"durationTicksFooOneWay2:             {durationTicksFooOneWay2}");
+
+                    #endregion // Rpc
+
+                    #region InvokeAsync
+
+                    // Client calls server's method ProcessMessage
+                    var jarr = (JArray)await hubClient.InvokeAsync("ProcessMessage",
+                    new[]
+                    {
+                        new Message { ClientId = ".NETCoreClient", Data = 91, Args = new Arg1[]
+                            {
+                                new() { Id = "0", Arg2Props = new() { new() { Id = "0.0" }, new() { Id = "0.1" }, } },
+                                new() { Id = "1", Arg2Props = new() { new() { Id = "1.0" }, new() { Id = "1.1" }, } },
+                            }
+                        },
+                        new Message { ClientId = ".NETCoreClient", Data = 92, Args = new Arg1[]
+                            {
+                                new() { Id = "0", Arg2Props = new() { new() { Id = "0.0" }, new() { Id = "0.1" }, } },
+                                new() { Id = "1", Arg2Props = new() { new() { Id = "1.0" }, new() { Id = "1.1" }, } },
+                            }
+                        },
+                    });
+
+                    #endregion // InvokeAsync
+                }
+            });
+
+            Console.WriteLine("Press any key to cancel...");
+            Console.ReadKey();
+            ev.Set();
+            await hubClient.Cancel();
+
+            Console.WriteLine("Press any key to quit...");
+            Console.ReadKey();
+        }
+
+        static async Task<long> TimeWatch(Func<string, string, object[], Task<object>> func, string interfaceName, string methodName, params object[] args)
+        {
+            Stopwatch sw = new();
+            sw.Start();
+            var result = await func(interfaceName, methodName, args);
+            sw.Stop();
+            return sw.Elapsed.Ticks;
+        }
+
+        static async Task<long> TimeWatch(Action<string, string, object[]> action, string interfaceName, string methodName, params object[] args)
+        {
+            Stopwatch sw = new();
+            sw.Start();
+            action(interfaceName, methodName, args);
+            sw.Stop();
+            return sw.Elapsed.Ticks;
+        }
+    }
+}

--- a/SignalRClient/Properties/launchSettings.json
+++ b/SignalRClient/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "SignalRClientTest": {
+      "commandName": "Project",
+      "commandLineArgs": "TLS"
+    }
+  }
+}

--- a/SignalRClient/SignalRClient.csproj
+++ b/SignalRClient/SignalRClient.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;TLS</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\SignalRBaseHubClientLib\SignalRBaseHubClientLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SignalRSvc/Controllers/AboutController.cs
+++ b/SignalRSvc/Controllers/AboutController.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace SignalRSvc.Controllers
+{
+    [Route("api/[controller]")]
+    public class AboutController : Controller
+    {
+        [HttpGet]
+        public string Get() =>
+            "This is \"SignalRSvc\" service - a sample of SignalR usage";
+    }
+}

--- a/SignalRSvc/Hubs/AHub.cs
+++ b/SignalRSvc/Hubs/AHub.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using System.Text;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using SignalRBaseHubServerLib;
+using MessageProviderLib;
+using RemoteInterfaces;
+using RemoteImplementations;
+
+namespace SignalRSvc.Hubs
+{
+    // The hub class provides data streaming to client subscriber.
+    // This is implemented with its base class.
+    // The base class takes event provider as a ctor parameter. 
+    public class AHub : RpcAndStreamingHub<Message>
+    {
+        static AHub() 
+        {
+            RegisterPerCall<IRemoteCall1, RemoteCall1>();
+            RegisterPerSession<IRemoteCall2, RemoteCall2>();
+            RegisterSingleton<IRemoteCall3>(new RemoteCall3(5));
+        }
+
+        public AHub(ILoggerFactory loggerFactory)
+            : base(loggerFactory,
+                   MessageEventProvider.Instance,
+                   (logger, isDirectCall, requestId, clientId, interfaceName, methodName, methodArgs) =>
+                   {
+                       var whatCall = isDirectCall ? "direct" : "reflected";
+                       var message = $"Client: {clientId}, requestId = {requestId}. Before calling method '{interfaceName}.{methodName}()' - {whatCall} call";
+                       logger?.LogInformation(message);
+                   },
+                   (logger, isDirectCall, requestId, clientId, interfaceName, methodName, methodArgs, result, duration, exception) =>
+                   {
+                       var whatCall = isDirectCall ? "direct" : "reflected";
+                       var message = $"Client: {clientId}, requestId = {requestId}. After calling method '{interfaceName}.{methodName}()' - {whatCall} call, duration = {duration.TotalMilliseconds} ms";
+                       if (exception == null)
+                           logger?.LogInformation(message);
+                       else
+                           logger?.LogError(message, exception);
+                   })
+        {
+        }
+
+        public async Task<Message[]> ProcessMessage(Message[] args)
+        {
+            StringBuilder sbClients = new();
+            StringBuilder sbData = new();
+
+            if (args != null && args.Length > 0)
+            {
+                sbClients.Append("Clients: ");
+                foreach (var clientId in args.Select(dto => dto.ClientId).Distinct())
+                    sbClients.Append($"{clientId} ");
+
+                sbData.Append("--> Data: ");
+                foreach (var dto in args)
+                    sbData.Append($"{dto.Data} ");
+            }
+            else
+            {
+                sbClients.Append("No clients");
+                sbData.Append("No data available");
+            }
+
+            // Send message to all clients
+            await Clients.All.SendAsync("ReceiveMessage", sbClients.ToString(), sbData.ToString());
+
+            return args;
+        }
+    }
+}

--- a/SignalRSvc/Program.cs
+++ b/SignalRSvc/Program.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace SignalRSvc
+{
+    public class Program
+    {
+        const string URLS = "http://0.0.0.0:15000;https://0.0.0.0:15001";
+
+        public static void Main(string[] args) =>
+            CreateWebHostBuilder(args).Build().Run();
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                   .UseUrls(URLS)
+                   .UseStartup<Startup>();
+    }
+}

--- a/SignalRSvc/Properties/launchSettings.json
+++ b/SignalRSvc/Properties/launchSettings.json
@@ -1,0 +1,32 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:53486",
+      "sslPort": 44303
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SignalRSvc": {
+      "commandName": "Project",
+      "commandLineArgs": "TLS",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:15000;https://localhost:15001"
+    },
+    "Docker": {
+      "commandName": "Docker",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
+      "publishAllPorts": true,
+      "useSSL": true
+    }
+  }
+}

--- a/SignalRSvc/SignalRSvc.csproj
+++ b/SignalRSvc/SignalRSvc.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <UserSecretsId>6b46546b-912f-4a2b-a922-85440b40e4a1</UserSecretsId>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;TLS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+    <PackageReference Include="System.Reactive.Linq" Version="4.1.2" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\SignalRBaseHubServerLib\SignalRBaseHubServerLib.csproj" />
+    <ProjectReference Include="..\MessageProviderLib\MessageProviderLib.csproj" />
+    <ProjectReference Include="..\RemoteCallable\RemoteImplementations\RemoteImplementations.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SignalRSvc/Startup.cs
+++ b/SignalRSvc/Startup.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SignalRSvc.Hubs;
+
+namespace SignalRSvc
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers().AddNewtonsoftJson();
+
+            // Add CORS
+            services.AddCors(o => o.AddPolicy("CORSPolicy", builder =>
+                builder.AllowAnyOrigin()
+                       .AllowAnyMethod()
+                       .AllowAnyHeader()
+            ));
+
+            services.AddSingleton(Configuration);
+
+            services.AddSignalR();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                app.UseHsts();
+            }
+
+            //app.UseHttpsRedirection();
+
+            app.UseStaticFiles();
+            app.UseCookiePolicy();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            // Add CORS middleware before MVC
+            app.UseCors("CORSPolicy");
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHub<AHub>("/hub/a", options =>
+                {
+                    options.Transports =
+                        HttpTransportType.WebSockets |
+                        HttpTransportType.LongPolling;
+                });
+                endpoints.MapControllers();            
+            });
+        }
+    }
+}

--- a/SignalRSvc/appsettings.Development.json
+++ b/SignalRSvc/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/SignalRSvc/appsettings.json
+++ b/SignalRSvc/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/_build_solution.cmd
+++ b/_build_solution.cmd
@@ -1,0 +1,1 @@
+dotnet build -o bin -c Release

--- a/_run_Client.cmd
+++ b/_run_Client.cmd
@@ -1,0 +1,2 @@
+cd bin
+SignalRClient.exe TLS

--- a/_run_Server.cmd
+++ b/_run_Server.cmd
@@ -1,0 +1,2 @@
+cd bin
+SignalRSvc.exe TLS


### PR DESCRIPTION
Solution provides the following functionality for inter-process communication in .NET 5:

RPC using interface, particularly to replace WCF
RPC with asynchronous response, and
Streaming
The solution is based on SignalR library. It uses WebSocket as its main transport type with long polling as a fallback.

The following features are supported:

Binaries run in Windows and Linux alike
Communication channel may be encrypted with TLS.
Client is not necessarily .NET . It may be e. g. front end Web application.